### PR TITLE
Fixed issue link typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - Documentation: [https://melonly-api.readthedocs.io/](https://melonly-api.readthedocs.io/)
 - Issues: [https://github.com/Melonly-Moderation/ts-melonly-client/issues](https://github.com/Melonly-Moderation/ts-melonly-client/issues)
-- Melonly API Documentation: [https://api.melonly.xyz/docs](https://api.melonly.xyz/docs)
+- Melonly API Documentation: [https://apidocs.melonly.xyz/](https://apidocs.melonly.xyz/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 💬 Support
 
 - Documentation: [https://melonly-api.readthedocs.io/](https://melonly-api.readthedocs.io/)
-- Issues: [https://github.com/Melonly-Moderation/ts-melonly-client/issues](https://github.com/ts-melonly-client/ts-melonly-client/issues)
+- Issues: [https://github.com/Melonly-Moderation/ts-melonly-client/issues](https://github.com/Melonly-Moderation/ts-melonly-client/issues)
 - Melonly API Documentation: [https://api.melonly.xyz/docs](https://api.melonly.xyz/docs)
 
 ---


### PR DESCRIPTION
There was a link typo in the README.md
it was `https://github.com/ts-melonly-client/ts-melonly-client/issues` I changed it to `https://github.com/Melonly-Moderation/ts-melonly-client/issues`